### PR TITLE
refactor: request userId관련 헤더 내용 스웨거 포함 제거

### DIFF
--- a/hobbyhobby-user/hobbyhobby-api/src/main/java/org/v1/domain/user/controller/UserController.java
+++ b/hobbyhobby-user/hobbyhobby-api/src/main/java/org/v1/domain/user/controller/UserController.java
@@ -25,7 +25,7 @@ public class UserController {
     @Operation(summary = "유저 정보 삭제")
     @Parameter(name = "Authorization", description = "Access token", required = true, in = ParameterIn.HEADER)
     public HttpResponse<Object> removeUser(
-            @Valid @RequestHeader Long userId
+            @Parameter(hidden = true) @Valid @RequestHeader Long userId
     ) {
         userService.removeUser(userId);
         return HttpResponse.successOnly();
@@ -34,7 +34,7 @@ public class UserController {
     @GetMapping("/mypage")
     @Parameter(name = "Authorization", description = "Access token", required = true, in = ParameterIn.HEADER)
     public HttpResponse<UserGetMyPageResponse> getMyPage(
-            @Valid @RequestHeader Long userId
+            @Parameter(hidden = true) @Valid @RequestHeader Long userId
     ) {
         User user = userService.getMyPage(userId);
         UserGetMyPageResponse response =UserGetMyPageResponse.of(user);


### PR DESCRIPTION
gateway에서 jwt 안에 있는 userId 을 파싱해 헤더에 넣어서 전송함으로 스웨거에 표시 필요 없다